### PR TITLE
mayhem integration v2

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: 'build mayhem fuzzing container'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: mayhem/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+
+  mayhem:
+    needs: build
+    name: 'fuzz ${{ matrix.mayhemfile }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mayhemfile:
+          - mayhem/compile.mayhemfile
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start analysis for ${{ matrix.mayhemfile }}
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ needs.build.outputs.image }} --file ${{ matrix.mayhemfile }} --duration 300
+          sarif-output: sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM rust:latest as builder
-COPY . /rant
-WORKDIR /rant
-RUN cargo build --features cli
-
-FROM debian:bullseye-slim
-COPY --from=builder /rant/target/debug/rant .

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,5 +1,0 @@
-project: rant
-target: rant
-
-cmds:
-    - cmd: ./rant @@

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rant-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.rant]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "compile"
+path = "fuzz_targets/compile.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let rant = rant::Rant::new();
+    _ = rant.compile_quiet(data);
+});

--- a/mayhem/.dockerignore
+++ b/mayhem/.dockerignore
@@ -1,0 +1,3 @@
+/target
+.git
+mayhem/Dockerfile

--- a/mayhem/Dockerfile
+++ b/mayhem/Dockerfile
@@ -1,0 +1,22 @@
+# Build Stage
+FROM ghcr.io/evanrichter/cargo-fuzz:latest as builder
+
+## Add source code to the build stage.
+ADD . /src
+WORKDIR /src
+
+RUN echo building instrumented harnesses && \
+    bash -c "pushd fuzz && cargo +nightly -Z sparse-registry fuzz build && popd" && \
+    mv fuzz/target/x86_64-unknown-linux-gnu/release/compile /compile && \
+    echo done
+
+RUN echo building non-instrumented harnesses && \
+    export RUSTFLAGS="--cfg fuzzing -Clink-dead-code -Cdebug-assertions -C codegen-units=1" && \
+    bash -c "pushd fuzz && cargo +nightly -Z sparse-registry build --release && popd" && \
+    mv fuzz/target/release/compile /compile_no_inst && \
+    echo done
+
+# Package Stage
+FROM rustlang/rust:nightly
+
+COPY --from=builder /compile /compile_no_inst /

--- a/mayhem/compile.mayhemfile
+++ b/mayhem/compile.mayhemfile
@@ -1,0 +1,7 @@
+project: rant
+target: compile
+
+cmds:
+  - cmd: /compile
+  - cmd: /compile_no_inst @@
+    libfuzzer: false


### PR DESCRIPTION
this PR updates the mayhem fuzzer to specifically harness the compilation pipeline (parsing, lexing, etc) using a [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) harness. this docker image also builds the harness twice: once with libfuzzer & ASAN instrumentation and once with no instrumentation (to enable effective symbolic execution)